### PR TITLE
알림 서비스 로직 수정

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+CHROME_EXECUTABLE_PATH=/opt/homebrew/bin/chromium
+CHROME_HEADLESS=false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,8 @@ name: CD
 on:
   push:
     branches:
-      - master
+      - test/prod-cd
+      # - master
     paths-ignore:
       - README.md
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,12 @@
     "aws-sdk": "^2.1669.0",
     "axios": "^1.7.3",
     "cheerio": "1.0.0-rc.12",
+    "chrome-aws-lambda": "^10.1.0",
     "dayjs": "^1.11.12",
     "dotenv": "^16.4.5",
     "nodemailer": "^6.9.14",
     "pg": "^8.12.0",
-    "puppeteer": "^22.15.0",
+    "puppeteer-core": "^23.0.2",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
+      chrome-aws-lambda:
+        specifier: ^10.1.0
+        version: 10.1.0(puppeteer-core@23.0.2)
       dayjs:
         specifier: ^1.11.12
         version: 1.11.12
@@ -56,9 +59,9 @@ importers:
       pg:
         specifier: ^8.12.0
         version: 8.12.0
-      puppeteer:
-        specifier: ^22.15.0
-        version: 22.15.0(typescript@5.5.4)
+      puppeteer-core:
+        specifier: ^23.0.2
+        version: 23.0.2
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2
@@ -1733,12 +1736,18 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chrome-aws-lambda@10.1.0:
+    resolution: {integrity: sha512-NZQVf+J4kqG4sVhRm3WNmOfzY0OtTSm+S8rg77pwePa9RCYHzhnzRs8YvNI6L9tALIW6RpmefWiPURt3vURXcw==}
+    engines: {node: '>= 10.16'}
+    peerDependencies:
+      puppeteer-core: ^10.1.0
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromium-bidi@0.6.3:
-    resolution: {integrity: sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==}
+  chromium-bidi@0.6.4:
+    resolution: {integrity: sha512-8zoq6ogmhQQkAKZVKO2ObFTl4uOkqoX1PlKQX3hZQ5E9cbUotcAb7h4pTNVAGGv8Z36PF3CtdOriEp/Rz82JqQ==}
     peerDependencies:
       devtools-protocol: '*'
 
@@ -1870,15 +1879,6 @@ packages:
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -2062,10 +2062,6 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
-
-  env-paths@2.2.1:
-    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
-    engines: {node: '>=6'}
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -2878,6 +2874,13 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
+  lambdafs@2.1.1:
+    resolution: {integrity: sha512-x5k8JcoJWkWLvCVBzrl4pzvkEHSgSBqFjg3Dpsc4AcTMq7oUMym4cL/gRTZ6VM4mUMY+M0dIbQ+V1c1tsqqanQ==}
+    engines: {node: '>= 10.16'}
+    hasBin: true
+    bundledDependencies:
+      - tar-fs
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -3403,14 +3406,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  puppeteer-core@22.15.0:
-    resolution: {integrity: sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==}
+  puppeteer-core@23.0.2:
+    resolution: {integrity: sha512-MvOHn+g1TYkAR2oVd/bf/YWXKqFTJmkhyyurYgxkrjh8rBOL1ZH5VyOsLJi0bLO7/yoipAmk1gFZEx9HUJnaoA==}
     engines: {node: '>=18'}
-
-  puppeteer@22.15.0:
-    resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -6502,9 +6500,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chrome-aws-lambda@10.1.0(puppeteer-core@23.0.2):
+    dependencies:
+      lambdafs: 2.1.1
+      puppeteer-core: 23.0.2
+
   chrome-trace-event@1.0.4: {}
 
-  chromium-bidi@0.6.3(devtools-protocol@0.0.1312386):
+  chromium-bidi@0.6.4(devtools-protocol@0.0.1312386):
     dependencies:
       devtools-protocol: 0.0.1312386
       mitt: 3.0.1
@@ -6632,15 +6635,6 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.3.3
-
-  cosmiconfig@9.0.0(typescript@5.5.4):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.5.4
 
   create-jest@29.7.0(@types/node@20.14.13)(ts-node@10.9.2(@types/node@20.14.13)(typescript@5.5.4)):
     dependencies:
@@ -6797,8 +6791,6 @@ snapshots:
       tapable: 2.2.1
 
   entities@4.5.0: {}
-
-  env-paths@2.2.1: {}
 
   error-ex@1.3.2:
     dependencies:
@@ -7907,6 +7899,8 @@ snapshots:
 
   kleur@3.0.3: {}
 
+  lambdafs@2.1.1: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -8374,28 +8368,16 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@22.15.0:
+  puppeteer-core@23.0.2:
     dependencies:
       '@puppeteer/browsers': 2.3.0
-      chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
+      chromium-bidi: 0.6.4(devtools-protocol@0.0.1312386)
       debug: 4.3.6
       devtools-protocol: 0.0.1312386
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
-      - utf-8-validate
-
-  puppeteer@22.15.0(typescript@5.5.4):
-    dependencies:
-      '@puppeteer/browsers': 2.3.0
-      cosmiconfig: 9.0.0(typescript@5.5.4)
-      devtools-protocol: 0.0.1312386
-      puppeteer-core: 22.15.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
       - utf-8-validate
 
   pure-rand@6.1.0: {}

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,14 @@ provider:
   environment:
     NODE_ENV: ${self:provider.stage}
     MODE: lambda
+  vpc:
+    securityGroupIds:
+      - ${env:AWS_VPC_SECURITY_GROUP_ID}
+    subnetIds:
+      - ${env:AWS_VPC_SECURITY_SUBNET_ID_1}
+      - ${env:AWS_VPC_SECURITY_SUBNET_ID_2}
+      - ${env:AWS_VPC_SECURITY_SUBNET_ID_3}
+      - ${env:AWS_VPC_SECURITY_SUBNET_ID_4}
   iam:
     role:
       statements:

--- a/src/handlers/notifications.ts
+++ b/src/handlers/notifications.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { NotificationsService } from '../notifications/notifications.service';
+import { Context, ScheduledEvent } from 'aws-lambda';
+
+export const processNotifications = async (
+  event: ScheduledEvent,
+  context: Context,
+) => {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const notificationsService = app.get(NotificationsService);
+
+  await notificationsService.processNotifications();
+
+  await app.close();
+};
+
+export const retryFailedNotifications = async (
+  event: ScheduledEvent,
+  context: Context,
+) => {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const notificationsService = app.get(NotificationsService);
+
+  await notificationsService.retryFailedNotifications();
+
+  await app.close();
+};

--- a/src/handlers/scrapers.ts
+++ b/src/handlers/scrapers.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+import { Context, ScheduledEvent } from 'aws-lambda';
+import { ScrapersService } from '../scrapers/scrapers.service';
+import { HospitalName } from '../common/enums/hospital-name.enum';
+
+export const scrapeSeverance = async (
+  event: ScheduledEvent,
+  context: Context,
+) => {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  const scrapersService = app.get(ScrapersService);
+
+  await scrapersService.scrapeOne(HospitalName.Severance);
+
+  await app.close();
+};

--- a/src/job-posts/job-posts.service.ts
+++ b/src/job-posts/job-posts.service.ts
@@ -9,6 +9,7 @@ import { NotificationType } from '../notifications/enums/notification-type.enum'
 import { CreateNotificationDto } from '../notifications/dto/notification.dto';
 import { SubscriptionEntity } from '../subscriptions/entities/subscriptions.entity';
 import { HospitalName } from '../common/enums/hospital-name.enum';
+import dayjs from 'dayjs';
 
 @Injectable()
 export class JobPostsService {
@@ -63,6 +64,13 @@ export class JobPostsService {
     const notifications: CreateNotificationDto[] = [];
 
     for (const jobPost of jobPosts) {
+      const isActive = dayjs(jobPost.endAt).isAfter(dayjs());
+
+      if (!isActive) {
+        this.logger.log(`Skipping inactive job post: ${jobPost.title}`);
+        continue;
+      }
+
       const relevantSubscriptions = subscriptions.filter(
         (sub) =>
           sub.hospitalName === jobPost.hospitalName &&

--- a/src/job-posts/job-posts.service.ts
+++ b/src/job-posts/job-posts.service.ts
@@ -80,6 +80,7 @@ export class JobPostsService {
             subject: `새로운 채용 공고: ${jobPost.title}`,
             html: this.generateEmailHtml(jobPost, subscription),
           },
+          jobPostId: jobPost.id,
         });
       }
     }

--- a/src/notifications/dto/notification.dto.ts
+++ b/src/notifications/dto/notification.dto.ts
@@ -5,6 +5,7 @@ export class CreateNotificationDto extends PickType(NotificationEntity, [
   'type',
   'recipient',
   'content',
+  'jobPostId',
 ] as const) {}
 
 export type NotificationContent = {

--- a/src/notifications/entities/notifications.entity.ts
+++ b/src/notifications/entities/notifications.entity.ts
@@ -4,9 +4,12 @@ import {
   PrimaryGeneratedColumn,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToOne,
+  JoinColumn,
 } from 'typeorm';
 import { NotificationType } from '../enums/notification-type.enum';
 import { NotificationContent } from '../dto/notification.dto';
+import { JobPostEntity } from '../../job-posts/entities/job-post.entity';
 
 export enum NotificationStatus {
   PENDING = 'pending',
@@ -38,6 +41,13 @@ export class NotificationEntity {
     default: NotificationStatus.PENDING,
   })
   status: NotificationStatus;
+
+  @OneToOne(() => JobPostEntity)
+  @JoinColumn()
+  jobPost: JobPostEntity;
+
+  @Column({ nullable: true })
+  jobPostId: number;
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;

--- a/src/scrapers/scrapers.module.ts
+++ b/src/scrapers/scrapers.module.ts
@@ -4,9 +4,11 @@ import { JobPostsModule } from '../job-posts/job-posts.module';
 import { scrapers } from './strategies';
 import { SCRAPING_STRATEGIES } from './interfaces/scraping-strategy.interface';
 import { ScrapersScheduler } from './scrapers.scheduler';
+import { ScrapersController } from './scrapers.controller';
 
 @Module({
   imports: [JobPostsModule],
+  controllers: [ScrapersController],
   providers: [
     ...scrapers,
     {

--- a/src/scrapers/scrapers.scheduler.ts
+++ b/src/scrapers/scrapers.scheduler.ts
@@ -11,7 +11,7 @@ export class ScrapersScheduler {
   constructor(private readonly scrapersService: ScrapersService) {}
 
   @Cron(CronExpression.EVERY_HOUR)
-  async handleCron() {
+  async scrapeSeverance() {
     this.logger.debug('Processing scrapers');
 
     await this.scrapersService.scrapeOne(HospitalName.Severance);

--- a/src/scrapers/strategies/severance-scraping.strategy.ts
+++ b/src/scrapers/strategies/severance-scraping.strategy.ts
@@ -95,12 +95,15 @@ export class SeveranceScrapingStrategy implements ScrapingStrategy {
         const [startAt, endAt] =
           dateElement.textContent?.trim().split('~') ?? [];
 
+        const params = new URLSearchParams(linkElement.href.split('?')[1]);
+        const jobnoticeSn = params.get('jobnoticeSn');
+
         return {
-          title: titleElement.textContent?.trim() ?? '',
+          title: titleElement.textContent?.trim(),
           url: linkElement.href,
-          externalId: linkElement.href.split('/').pop() ?? '',
-          startAt: startAt?.trim() ?? '',
-          endAt: endAt?.trim() ?? '',
+          externalId: jobnoticeSn,
+          startAt: startAt?.trim(),
+          endAt: endAt?.trim(),
         };
       });
     });

--- a/src/scrapers/strategies/severance-scraping.strategy.ts
+++ b/src/scrapers/strategies/severance-scraping.strategy.ts
@@ -42,7 +42,11 @@ export class SeveranceScrapingStrategy implements ScrapingStrategy {
             break;
           }
 
-          allJobs.push(job);
+          if (
+            allJobs.findIndex((j) => j.externalId === job.externalId) === -1
+          ) {
+            allJobs.push(job);
+          }
         }
 
         if (isDuplicateFound || !(await this.goToNextPage(page))) {


### PR DESCRIPTION
이 PR은 알림서비스 로직 및 스크래핑 고도화 입니다.

변경 사항:
- Notifications에 JobPosts 외래키 추가
- 스크래핑 API 등록
- 마감일이 안지난 공고만 노티하도록 수정
- 스크래핑 중복 제거 로직 추가
- puppeteer-core로 변경 (Lambda 환경에선 Chrome이 없는 문제로 인한 별도 크롬 설치, puppeteer의 크롬은 무거움)
- Severless VPC 설정 추가
- CD WorkFlow 비활성화 (RDS public 과금 문제로 인한 아키텍처 수정 필요)