### PR TITLE
EC2 프로덕션 환경에 크로미움 활성화

### DIFF
--- a/.github/workflows/cd-ec2.yml
+++ b/.github/workflows/cd-ec2.yml
@@ -1,4 +1,4 @@
-name: CI/CD Pipeline
+name: CD EC2
 
 on:
   push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CD Serverless
 
 on:
   push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,18 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# Install Chromium and its minimal dependencies
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    harfbuzz \
+    ca-certificates
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    CHROME_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 # Copy built assets from the build stage
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "aws-sdk": "^2.1669.0",
     "axios": "^1.7.3",
     "cheerio": "1.0.0-rc.12",
-    "chrome-aws-lambda": "^10.1.0",
     "dayjs": "^1.11.12",
     "dotenv": "^16.4.5",
     "nodemailer": "^6.9.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       cheerio:
         specifier: 1.0.0-rc.12
         version: 1.0.0-rc.12
-      chrome-aws-lambda:
-        specifier: ^10.1.0
-        version: 10.1.0(puppeteer-core@23.0.2)
       dayjs:
         specifier: ^1.11.12
         version: 1.11.12
@@ -1736,12 +1733,6 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chrome-aws-lambda@10.1.0:
-    resolution: {integrity: sha512-NZQVf+J4kqG4sVhRm3WNmOfzY0OtTSm+S8rg77pwePa9RCYHzhnzRs8YvNI6L9tALIW6RpmefWiPURt3vURXcw==}
-    engines: {node: '>= 10.16'}
-    peerDependencies:
-      puppeteer-core: ^10.1.0
-
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
@@ -2873,13 +2864,6 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
-
-  lambdafs@2.1.1:
-    resolution: {integrity: sha512-x5k8JcoJWkWLvCVBzrl4pzvkEHSgSBqFjg3Dpsc4AcTMq7oUMym4cL/gRTZ6VM4mUMY+M0dIbQ+V1c1tsqqanQ==}
-    engines: {node: '>= 10.16'}
-    hasBin: true
-    bundledDependencies:
-      - tar-fs
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -6500,11 +6484,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chrome-aws-lambda@10.1.0(puppeteer-core@23.0.2):
-    dependencies:
-      lambdafs: 2.1.1
-      puppeteer-core: 23.0.2
-
   chrome-trace-event@1.0.4: {}
 
   chromium-bidi@0.6.4(devtools-protocol@0.0.1312386):
@@ -7898,8 +7877,6 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@3.0.3: {}
-
-  lambdafs@2.1.1: {}
 
   leven@3.1.0: {}
 

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,6 +1,6 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
 import { config } from 'dotenv';
-import { S3 } from 'aws-sdk';
+// import { S3 } from 'aws-sdk';
 
 const NODE_ENV = process.env.NODE_ENV || 'production';
 
@@ -15,52 +15,52 @@ config({
 
 const isProduction = NODE_ENV === 'production';
 
-const getCertificateFromS3 = async (
-  bucket: string | undefined,
-  key: string | undefined,
-): Promise<string> => {
-  if (!bucket || !key) {
-    throw new Error('S3 bucket or key is not provided');
-  }
+// const getCertificateFromS3 = async (
+//   bucket: string | undefined,
+//   key: string | undefined,
+// ): Promise<string> => {
+//   if (!bucket || !key) {
+//     throw new Error('S3 bucket or key is not provided');
+//   }
 
-  const s3 = new S3({
-    region: process.env.AWS_REGION,
-  });
+//   const s3 = new S3({
+//     region: process.env.AWS_REGION,
+//   });
 
-  try {
-    const data = await s3
-      .getObject({
-        Bucket: bucket,
-        Key: key,
-      })
-      .promise();
+//   try {
+//     const data = await s3
+//       .getObject({
+//         Bucket: bucket,
+//         Key: key,
+//       })
+//       .promise();
 
-    if (!data.Body) {
-      throw new Error('S3 object body is empty');
-    }
+//     if (!data.Body) {
+//       throw new Error('S3 object body is empty');
+//     }
 
-    return data.Body.toString('utf-8');
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new Error(
-        `Failed to retrieve certificate from S3: ${error.message}`,
-      );
-    }
-    throw new Error(
-      'An unknown error occurred while retrieving the certificate from S3',
-    );
-  }
-};
+//     return data.Body.toString('utf-8');
+//   } catch (error) {
+//     if (error instanceof Error) {
+//       throw new Error(
+//         `Failed to retrieve certificate from S3: ${error.message}`,
+//       );
+//     }
+//     throw new Error(
+//       'An unknown error occurred while retrieving the certificate from S3',
+//     );
+//   }
+// };
 
 const createDataSource = async (): Promise<DataSource> => {
   let sslCa: string | undefined;
 
   if (isProduction) {
     try {
-      sslCa = await getCertificateFromS3(
-        process.env.SSL_CERTIFICATE_S3_BUCKET,
-        process.env.SSL_CERTIFICATE_S3_KEY,
-      );
+      // sslCa = await getCertificateFromS3(
+      //   process.env.SSL_CERTIFICATE_S3_BUCKET,
+      //   process.env.SSL_CERTIFICATE_S3_KEY,
+      // );
     } catch (error) {
       console.error('Error retrieving SSL certificate:', error);
       // 여기서 에러를 던지거나 기본 동작을 결정해야 합니다.
@@ -82,13 +82,11 @@ const createDataSource = async (): Promise<DataSource> => {
     entities: ['src/**/*.entity{.ts,.js}'],
     migrations: ['src/database/migrations/**/*{.ts,.js}'],
     subscribers: [],
-    ...(isProduction &&
-      sslCa && {
-        ssl: {
-          rejectUnauthorized: false,
-          ca: sslCa,
-        },
-      }),
+    ...(isProduction && {
+      ssl: {
+        rejectUnauthorized: false,
+      },
+    }),
   };
 
   return new DataSource(dataSourceOptions);

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -53,7 +53,7 @@ const isProduction = NODE_ENV === 'production';
 // };
 
 const createDataSource = async (): Promise<DataSource> => {
-  let sslCa: string | undefined;
+  // let sslCa: string | undefined;
 
   if (isProduction) {
     try {


### PR DESCRIPTION
[backgruond]
- ec2 환경에서 크로미움이 활성화가 안되는 문제

[to-be]
- docker에 크로미움을 포함시켜 활성화
- CHROME_EXECUTABLE_PATH 환경 변수로 크로미움 위치 지정
- DB SSL 인증 비활성화 (S3 프리티어 초과)

추후 Serverless 환경으로 전환시 `@sparticuz/chromium` 라이브러리를 이용한 크로미움 설정이 필요합니다.